### PR TITLE
Fixed unwind safe within `zip_elements`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,13 +172,14 @@ impl<A, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Matrix<A, M, N> {
     #[inline] fn map_elements<B, F: FnMut(A) -> B>(self, mut f: F) -> Matrix<B, M, N>
       where M: ArrayLength<B>, N: ArrayLength<GenericArray<B, M>> {
         let Matrix(a) = self;
+        let _wrapper = mem::ManuallyDrop::new(a);
         let mut c: GenericArray<GenericArray<B, M>, N> = unsafe { mem::uninitialized() };
         for i in 0..N::to_usize() { for j in 0..M::to_usize() { unsafe {
-            ptr::write(&mut c[i][j], f(ptr::read(&a[i][j])))
+            ptr::write(&mut c[i][j], f(ptr::read(&_wrapper[i][j])))
         } } }
-        mem::forget(a);
         Matrix(c)
     }
+
 }
 
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@ mod mat;
 
 #[cfg(feature = "glium")]
 mod linea_glium;
-
 #[cfg(feature = "glium")]
 pub use linea_glium::*;
 
@@ -38,7 +37,7 @@ use core::ptr;
 use generic_array::*;
 use idem::*;
 use radical::Radical;
-use typenum::consts::{U1, U2};
+use typenum::consts::{ U1, U2 };
 
 #[doc(hidden)]
 pub use generic_array::GenericArray as __linea_GenericArray;
@@ -49,7 +48,7 @@ pub struct Matrix<A, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>> = U1>
 #[inline]
 pub fn dot<B: Copy, A: Copy + Mul<B>, N: ArrayLength<A> + ArrayLength<B>>(Matrix(a): Matrix<A, N>, Matrix(b): Matrix<B, N>) -> A::Output where A::Output: Zero + AddAssign {
     let mut c = A::Output::zero;
-    for i in 0..N::to_usize() { c += a[0][i] * b[0][i] }
+    for i in 0..N::to_usize() { c += a[0][i]*b[0][i] }
     c
 }
 
@@ -64,7 +63,7 @@ impl<A, N: ArrayLength<A>> IndexMut<usize> for Matrix<A, N> {
     fn index_mut(&mut self, i: usize) -> &mut A { &mut self.0[0][i] }
 }
 
-impl<A: Copy + Zero + AddAssign + Mul + Div, N: ArrayLength<A> + ArrayLength<<A as Div>::Output>> Matrix<A, N> where <A as Mul>::Output: Zero + AddAssign + Radical<U2, Root=A>, <A as Div>::Output: Copy {
+impl<A: Copy + Zero + AddAssign + Mul + Div, N: ArrayLength<A> + ArrayLength<<A as Div>::Output>> Matrix<A, N> where <A as Mul>::Output: Zero + AddAssign + Radical<U2, Root = A>, <A as Div>::Output: Copy {
     /// Normalize.
     #[inline]
     pub fn norm(self) -> Matrix<<A as Div>::Output, N> where <N as ArrayLength<A>>::ArrayType: Copy { self.unscale(dot(self, self).root()) }
@@ -74,27 +73,25 @@ impl<A: Copy + Zero + AddAssign, N: ArrayLength<A>> Matrix<A, N> where N::ArrayT
     /// Project self onto other.
     #[inline]
     pub fn proj<B: Copy>(self, other: Matrix<B, N>) -> Self
-        where N: ArrayLength<B> + ArrayLength<<B as Mul>::Output> + ArrayLength<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output>, <N as ArrayLength<B>>::ArrayType: Copy,
-              A: Mul<B>, <A as Mul<B>>::Output: Zero + AddAssign + Div<<B as Mul>::Output>,
-              <<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output: Copy + Mul<B, Output=A>,
-              B: Mul + Mul<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output, Output=A>, <B as Mul>::Output: Zero + AddAssign { other.scale(dot(self, other) / dot(other, other)) }
+      where N: ArrayLength<B> + ArrayLength<<B as Mul>::Output> + ArrayLength<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output>, <N as ArrayLength<B>>::ArrayType: Copy,
+            A: Mul<B>, <A as Mul<B>>::Output: Zero + AddAssign + Div<<B as Mul>::Output>,
+            <<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output: Copy + Mul<B, Output = A>,
+            B: Mul + Mul<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output, Output = A>, <B as Mul>::Output: Zero + AddAssign { other.scale(dot(self, other)/dot(other, other)) }
 }
 
-impl<A: Copy + Zero + AddAssign + Sub<Output=A>, N: ArrayLength<A>> Matrix<A, N> where N::ArrayType: Copy {
+impl<A: Copy + Zero + AddAssign + Sub<Output = A>, N: ArrayLength<A>> Matrix<A, N> where N::ArrayType: Copy {
     /// Reject self from other.
     #[inline]
     pub fn rej<B: Copy>(self, other: Matrix<B, N>) -> Self
-        where N: ArrayLength<B> + ArrayLength<<B as Mul>::Output> + ArrayLength<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output>, <N as ArrayLength<B>>::ArrayType: Copy,
-              A: Mul<B>, <A as Mul<B>>::Output: Zero + AddAssign + Div<<B as Mul>::Output>,
-              <<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output: Copy + Mul<B, Output=A>,
-              B: Mul + Mul<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output, Output=A>, <B as Mul>::Output: Zero + AddAssign { self - self.proj(other) }
+      where N: ArrayLength<B> + ArrayLength<<B as Mul>::Output> + ArrayLength<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output>, <N as ArrayLength<B>>::ArrayType: Copy,
+            A: Mul<B>, <A as Mul<B>>::Output: Zero + AddAssign + Div<<B as Mul>::Output>,
+            <<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output: Copy + Mul<B, Output = A>,
+            B: Mul + Mul<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output, Output = A>, <B as Mul>::Output: Zero + AddAssign { self - self.proj(other) }
 }
 
 impl<A, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Matrix<A, M, N> {
-    #[inline]
-    pub const fn from_col_major_array(a: GenericArray<GenericArray<A, M>, N>) -> Self { Matrix(a) }
-    #[inline]
-    pub const fn to_col_major_array(self) -> GenericArray<GenericArray<A, M>, N> {
+    #[inline] pub const fn from_col_major_array(a: GenericArray<GenericArray<A, M>, N>) -> Self { Matrix(a) }
+    #[inline] pub const fn to_col_major_array(self) -> GenericArray<GenericArray<A, M>, N> {
         #[allow(unions_with_drop_fields)]
         union U<A, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> { a: Matrix<A, M, N> }
         let u = U { a: self };
@@ -119,19 +116,18 @@ impl<A: Copy + Zero, M: ArrayLength<A>> Matrix<A, M> {
 impl<A, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Matrix<A, M, N> {
     #[inline]
     pub fn scale<B: Copy>(self, b: B) -> Matrix<A::Output, M, N>
-        where A: Mul<B>,
-              M: ArrayLength<A::Output>,
-              N: ArrayLength<GenericArray<A::Output, M>> { self.map_elements(|a| a * b) }
+      where A: Mul<B>,
+            M: ArrayLength<A::Output>,
+            N: ArrayLength<GenericArray<A::Output, M>> { self.map_elements(|a| a*b) }
     #[inline]
     pub fn unscale<B: Copy>(self, b: B) -> Matrix<A::Output, M, N>
-        where A: Div<B>,
-              M: ArrayLength<A::Output>,
-              N: ArrayLength<GenericArray<A::Output, M>> { self.map_elements(|a| a / b) }
+      where A: Div<B>,
+            M: ArrayLength<A::Output>,
+            N: ArrayLength<GenericArray<A::Output, M>> { self.map_elements(|a| a/b) }
 }
 
 impl<A: Copy, M: ArrayLength<A> + ArrayLength<GenericArray<A, N>>, N: ArrayLength<A> + ArrayLength<GenericArray<A, M>>> Matrix<A, M, N> {
-    #[inline]
-    pub fn transpose(self) -> Matrix<A, N, M> {
+    #[inline] pub fn transpose(self) -> Matrix<A, N, M> {
         let Matrix(a) = self;
         let mut c: GenericArray<GenericArray<A, N>, M> = unsafe { mem::uninitialized() };
         for i in 0..N::to_usize() {
@@ -144,13 +140,11 @@ impl<A: Copy, M: ArrayLength<A> + ArrayLength<GenericArray<A, N>>, N: ArrayLengt
 }
 
 impl<A: Debug, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Debug for Matrix<A, M, N> {
-    #[inline]
-    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result { self.0.fmt(fmt) }
+    #[inline] fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result { self.0.fmt(fmt) }
 }
 
 impl<A: Clone, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Clone for Matrix<A, M, N> where M::ArrayType: Clone {
-    #[inline]
-    fn clone(&self) -> Self {
+    #[inline] fn clone(&self) -> Self {
         unsafe {
             let mut c: GenericArray<GenericArray<A, M>, N> = mem::uninitialized();
             for i in 0..N::to_usize() { for j in 0..M::to_usize() { ptr::write(&mut c[i][j], self.0[i][j].clone()) } }
@@ -162,37 +156,27 @@ impl<A: Clone, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Clone for 
 impl<A: Copy, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Copy for Matrix<A, M, N> where M::ArrayType: Copy, N::ArrayType: Copy {}
 
 impl<A: PartialEq, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> PartialEq for Matrix<A, M, N> {
-    #[inline]
-    fn eq(&self, &Matrix(ref b): &Self) -> bool {
-        let &Matrix(ref a) = self;
-        a == b
-    }
+    #[inline] fn eq(&self, &Matrix(ref b): &Self) -> bool { let &Matrix(ref a) = self; a == b }
 }
 
 impl<A: Eq, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Eq for Matrix<A, M, N> {}
 
 impl<B: Copy, A: Copy + MulAssign<B>, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> MulAssign<B> for Matrix<A, M, N> {
-    #[inline]
-    fn mul_assign(&mut self, rhs: B) {
+    #[inline] fn mul_assign(&mut self, rhs: B) {
         let &mut Matrix(ref mut a) = self;
         for i in 0..N::to_usize() { for j in 0..M::to_usize() { a[i][j] *= rhs } }
     }
 }
 
 impl<A, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Matrix<A, M, N> {
-    #[inline]
-    fn map_elements<B, F: FnMut(A) -> B>(self, mut f: F) -> Matrix<B, M, N>
-        where M: ArrayLength<B>, N: ArrayLength<GenericArray<B, M>> {
+    #[inline] fn map_elements<B, F: FnMut(A) -> B>(self, mut f: F) -> Matrix<B, M, N>
+      where M: ArrayLength<B>, N: ArrayLength<GenericArray<B, M>> {
         let Matrix(a) = self;
-        let wrapper = mem::ManuallyDrop::new(a);
+        let _wrapper = mem::ManuallyDrop::new(a);
         let mut c: GenericArray<GenericArray<B, M>, N> = unsafe { mem::uninitialized() };
-        for i in 0..N::to_usize() {
-            for j in 0..M::to_usize() {
-                unsafe {
-                    ptr::write(&mut c[i][j], f(ptr::read(&wrapper[i][j])))
-                }
-            }
-        }
+        for i in 0..N::to_usize() { for j in 0..M::to_usize() { unsafe {
+            ptr::write(&mut c[i][j], f(ptr::read(&_wrapper[i][j])))
+        }}}
         Matrix(c)
     }
 }
@@ -201,25 +185,20 @@ impl<A, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Matrix<A, M, N> {
 fn zip_elements<A, B, C, M, N, F: FnMut(A, B) -> C>(Matrix(a): Matrix<A, M, N>,
                                                     Matrix(b): Matrix<B, M, N>,
                                                     mut f: F) -> Matrix<C, M, N>
-    where M: ArrayLength<A> + ArrayLength<B> + ArrayLength<C>,
-          N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>> +
-          ArrayLength<GenericArray<C, M>> {
+  where M: ArrayLength<A> + ArrayLength<B> + ArrayLength<C>,
+        N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>> +
+           ArrayLength<GenericArray<C, M>> {
     let mut c: GenericArray<GenericArray<C, M>, N> = unsafe { mem::uninitialized() };
     let mut wrapper = mem::ManuallyDrop::new(c);
-    for i in 0..N::to_usize() {
-        for j in 0..M::to_usize() {
-            unsafe {
-                ptr::write(&mut wrapper[i][j], f(ptr::read(&a[i][j]), ptr::read(&b[i][j])))
-            }
-        }
-    }
+    for i in 0..N::to_usize() { for j in 0..M::to_usize() { unsafe {
+        ptr::write(&mut wrapper[i][j], f(ptr::read(&a[i][j]), ptr::read(&b[i][j])))
+    } } }
     mem::forget((a, b));
     Matrix(mem::ManuallyDrop::into_inner(wrapper))
 }
 
 impl<A: Copy + Zero, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Matrix<A, M, N> {
-    #[inline]
-    pub fn zero() -> Self {
+    #[inline] pub fn zero() -> Self {
         let mut c: GenericArray<GenericArray<A, M>, N> = unsafe { mem::uninitialized() };
         for i in 0..N::to_usize() { for j in 0..M::to_usize() { c[i][j] = A::zero } }
         Matrix(c)
@@ -228,50 +207,44 @@ impl<A: Copy + Zero, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Matr
 
 impl<A: Neg, M: ArrayLength<A> + ArrayLength<A::Output>, N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<A::Output, M>>> Neg for Matrix<A, M, N> {
     type Output = Matrix<A::Output, M, N>;
-    #[inline]
-    fn neg(self) -> Self::Output { self.map_elements(Neg::neg) }
+    #[inline] fn neg(self) -> Self::Output { self.map_elements(Neg::neg) }
 }
 
 impl<B: Copy, A: Copy + Add<B>,
-    M: ArrayLength<A> + ArrayLength<B> + ArrayLength<A::Output>,
-    N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>> + ArrayLength<GenericArray<A::Output, M>>> Add<Matrix<B, M, N>> for Matrix<A, M, N> {
+     M: ArrayLength<A> + ArrayLength<B> + ArrayLength<A::Output>,
+     N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>> + ArrayLength<GenericArray<A::Output, M>>> Add<Matrix<B, M, N>> for Matrix<A, M, N> {
     type Output = Matrix<A::Output, M, N>;
-    #[inline]
-    fn add(self, other: Matrix<B, M, N>) -> Self::Output { zip_elements(self, other, A::add) }
+    #[inline] fn add(self, other: Matrix<B, M, N>) -> Self::Output { zip_elements(self, other, A::add) }
 }
 
 impl<B: Copy, A: Copy + AddAssign<B>,
-    M: ArrayLength<A> + ArrayLength<B>,
-    N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>>> AddAssign<Matrix<B, M, N>> for Matrix<A, M, N> {
-    #[inline]
-    fn add_assign(&mut self, Matrix(b): Matrix<B, M, N>) {
+     M: ArrayLength<A> + ArrayLength<B>,
+     N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>>> AddAssign<Matrix<B, M, N>> for Matrix<A, M, N> {
+    #[inline] fn add_assign(&mut self, Matrix(b): Matrix<B, M, N>) {
         let &mut Matrix(ref mut a) = self;
         for i in 0..N::to_usize() { for j in 0..M::to_usize() { a[i][j] += b[i][j] } }
     }
 }
 
 impl<B: Copy, A: Copy + Sub<B>,
-    M: ArrayLength<A> + ArrayLength<B> + ArrayLength<A::Output>,
-    N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>> + ArrayLength<GenericArray<A::Output, M>>> Sub<Matrix<B, M, N>> for Matrix<A, M, N> {
+     M: ArrayLength<A> + ArrayLength<B> + ArrayLength<A::Output>,
+     N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>> + ArrayLength<GenericArray<A::Output, M>>> Sub<Matrix<B, M, N>> for Matrix<A, M, N> {
     type Output = Matrix<A::Output, M, N>;
-    #[inline]
-    fn sub(self, other: Matrix<B, M, N>) -> Self::Output { zip_elements(self, other, A::sub) }
+    #[inline] fn sub(self, other: Matrix<B, M, N>) -> Self::Output { zip_elements(self, other, A::sub) }
 }
 
 impl<B: Copy, A: Copy + SubAssign<B>,
-    M: ArrayLength<A> + ArrayLength<B>,
-    N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>>> SubAssign<Matrix<B, M, N>> for Matrix<A, M, N> {
-    #[inline]
-    fn sub_assign(&mut self, Matrix(b): Matrix<B, M, N>) {
+     M: ArrayLength<A> + ArrayLength<B>,
+     N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>>> SubAssign<Matrix<B, M, N>> for Matrix<A, M, N> {
+    #[inline] fn sub_assign(&mut self, Matrix(b): Matrix<B, M, N>) {
         let &mut Matrix(ref mut a) = self;
         for i in 0..N::to_usize() { for j in 0..M::to_usize() { a[i][j] -= b[i][j] } }
     }
 }
 
-impl<A: Copy + Zero + One, N: ArrayLength<A> + ArrayLength<GenericArray<A, N>>>
+impl<A: Copy + Zero + One, N: ArrayLength<A> + ArrayLength<GenericArray<A, N>>> 
 Matrix<A, N, N> {
-    #[inline]
-    pub fn one() -> Self {
+    #[inline] pub fn one() -> Self {
         let mut c: GenericArray<GenericArray<A, N>, N> = unsafe { mem::uninitialized() };
         for i in 0..N::to_usize() { for j in 0..N::to_usize() { c[i][j] = if i == j { A::one } else { A::zero } } }
         Matrix(c)
@@ -279,18 +252,17 @@ Matrix<A, N, N> {
 }
 
 impl<B: Copy, A: Copy + Mul<B>,
-    K: ArrayLength<B> + ArrayLength<GenericArray<A, M>>,
-    M: ArrayLength<A> + ArrayLength<A::Output>,
-    N: ArrayLength<GenericArray<A::Output, M>> + ArrayLength<GenericArray<B, K>>> Mul<Matrix<B, K, N>> for Matrix<A, M, K> where A::Output: Zero + AddAssign {
+     K: ArrayLength<B> + ArrayLength<GenericArray<A, M>>,
+     M: ArrayLength<A> + ArrayLength<A::Output>,
+     N: ArrayLength<GenericArray<A::Output, M>> + ArrayLength<GenericArray<B, K>>> Mul<Matrix<B, K, N>> for Matrix<A, M, K> where A::Output: Zero + AddAssign {
     type Output = Matrix<A::Output, M, N>;
-    #[inline]
-    fn mul(self, Matrix(b): Matrix<B, K, N>) -> Self::Output {
+    #[inline] fn mul(self, Matrix(b): Matrix<B, K, N>) -> Self::Output {
         let Matrix(a) = self;
         let mut c: GenericArray<GenericArray<A::Output, M>, N> = unsafe { mem::uninitialized() };
         for i in 0..N::to_usize() {
             for j in 0..M::to_usize() {
                 c[i][j] = A::Output::zero;
-                for k in 0..K::to_usize() { c[i][j] += a[k][j] * b[i][k] }
+                for k in 0..K::to_usize() { c[i][j] += a[k][j]*b[i][k] }
             }
         }
         Matrix(c)
@@ -299,8 +271,8 @@ impl<B: Copy, A: Copy + Mul<B>,
 
 #[cfg(feature = "dimensioned")]
 impl<A: dim::Dimensioned, M, N> dim::Dimensioned for Matrix<A, M, N>
-    where M: ArrayLength<A> + ArrayLength<A::Value>,
-          N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<A::Value, M>> {
+  where M: ArrayLength<A> + ArrayLength<A::Value>,
+        N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<A::Value, M>> {
     type Value = Matrix<A::Value, M, N>;
     type Units = A::Units;
     #[inline]
@@ -311,8 +283,8 @@ impl<A: dim::Dimensioned, M, N> dim::Dimensioned for Matrix<A, M, N>
 
 #[cfg(feature = "dimensioned")]
 impl<A: dim::Dimensionless, M, N> dim::Dimensionless for Matrix<A, M, N>
-    where M: ArrayLength<A> + ArrayLength<A::Value>,
-          N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<A::Value, M>> {
+  where M: ArrayLength<A> + ArrayLength<A::Value>,
+        N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<A::Value, M>> {
     #[inline]
     fn value(&self) -> &Self::Value { unsafe { mem::transmute(self) } }
 }
@@ -322,9 +294,9 @@ use quickcheck::*;
 
 #[cfg(any(test, feature = "quickcheck"))]
 impl<A: Copy + Arbitrary, M, N> Arbitrary for Matrix<A, M, N>
-    where M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>,
-          M::ArrayType: Clone, N::ArrayType: Send,
-          Matrix<A, M, N>: 'static {
+  where M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>,
+        M::ArrayType: Clone, N::ArrayType: Send,
+        Matrix<A, M, N>: 'static {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let mut c: GenericArray<GenericArray<A, M>, N> = unsafe { mem::uninitialized() };
         for i in 0..N::to_usize() {
@@ -344,14 +316,13 @@ mod tests {
     use super::*;
 
     fn test_multiply_transpose<A: Copy, M, N>(a: Matrix<A, M, N>, b: Matrix<A, N, M>) -> bool
-        where A: Mul, A::Output: Copy + PartialEq + Zero + AddAssign,
-              M: ArrayLength<A> + ArrayLength<GenericArray<A, N>> +
-              ArrayLength<A::Output> + ArrayLength<GenericArray<A::Output, M>>,
-              N: ArrayLength<A> + ArrayLength<GenericArray<A, M>>,
-              Matrix<A, M, N>: Copy, Matrix<A, N, M>: Copy {
-        (a * b).transpose() == b.transpose() * a.transpose()
+      where A: Mul, A::Output: Copy + PartialEq + Zero + AddAssign,
+            M: ArrayLength<A> + ArrayLength<GenericArray<A, N>> +
+               ArrayLength<A::Output> + ArrayLength<GenericArray<A::Output, M>>,
+            N: ArrayLength<A> + ArrayLength<GenericArray<A, M>>,
+            Matrix<A, M, N>: Copy, Matrix<A, N, M>: Copy {
+        (a*b).transpose() == b.transpose()*a.transpose()
     }
-
     #[quickcheck]
     fn multiply_transpose_3by4_isize(a: Matrix<isize, U3, U4>,
                                      b: Matrix<isize, U4, U3>) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,10 +172,10 @@ impl<A, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Matrix<A, M, N> {
     #[inline] fn map_elements<B, F: FnMut(A) -> B>(self, mut f: F) -> Matrix<B, M, N>
       where M: ArrayLength<B>, N: ArrayLength<GenericArray<B, M>> {
         let Matrix(a) = self;
-        let _wrapper = mem::ManuallyDrop::new(a);
+        let wrapper = mem::ManuallyDrop::new(a);
         let mut c: GenericArray<GenericArray<B, M>, N> = unsafe { mem::uninitialized() };
         for i in 0..N::to_usize() { for j in 0..M::to_usize() { unsafe {
-            ptr::write(&mut c[i][j], f(ptr::read(&_wrapper[i][j])))
+            ptr::write(&mut c[i][j], f(ptr::read(&wrapper[i][j])))
         }}}
         Matrix(c)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ mod mat;
 
 #[cfg(feature = "glium")]
 mod linea_glium;
+
 #[cfg(feature = "glium")]
 pub use linea_glium::*;
 
@@ -37,7 +38,7 @@ use core::ptr;
 use generic_array::*;
 use idem::*;
 use radical::Radical;
-use typenum::consts::{ U1, U2 };
+use typenum::consts::{U1, U2};
 
 #[doc(hidden)]
 pub use generic_array::GenericArray as __linea_GenericArray;
@@ -48,7 +49,7 @@ pub struct Matrix<A, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>> = U1>
 #[inline]
 pub fn dot<B: Copy, A: Copy + Mul<B>, N: ArrayLength<A> + ArrayLength<B>>(Matrix(a): Matrix<A, N>, Matrix(b): Matrix<B, N>) -> A::Output where A::Output: Zero + AddAssign {
     let mut c = A::Output::zero;
-    for i in 0..N::to_usize() { c += a[0][i]*b[0][i] }
+    for i in 0..N::to_usize() { c += a[0][i] * b[0][i] }
     c
 }
 
@@ -63,7 +64,7 @@ impl<A, N: ArrayLength<A>> IndexMut<usize> for Matrix<A, N> {
     fn index_mut(&mut self, i: usize) -> &mut A { &mut self.0[0][i] }
 }
 
-impl<A: Copy + Zero + AddAssign + Mul + Div, N: ArrayLength<A> + ArrayLength<<A as Div>::Output>> Matrix<A, N> where <A as Mul>::Output: Zero + AddAssign + Radical<U2, Root = A>, <A as Div>::Output: Copy {
+impl<A: Copy + Zero + AddAssign + Mul + Div, N: ArrayLength<A> + ArrayLength<<A as Div>::Output>> Matrix<A, N> where <A as Mul>::Output: Zero + AddAssign + Radical<U2, Root=A>, <A as Div>::Output: Copy {
     /// Normalize.
     #[inline]
     pub fn norm(self) -> Matrix<<A as Div>::Output, N> where <N as ArrayLength<A>>::ArrayType: Copy { self.unscale(dot(self, self).root()) }
@@ -73,25 +74,27 @@ impl<A: Copy + Zero + AddAssign, N: ArrayLength<A>> Matrix<A, N> where N::ArrayT
     /// Project self onto other.
     #[inline]
     pub fn proj<B: Copy>(self, other: Matrix<B, N>) -> Self
-      where N: ArrayLength<B> + ArrayLength<<B as Mul>::Output> + ArrayLength<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output>, <N as ArrayLength<B>>::ArrayType: Copy,
-            A: Mul<B>, <A as Mul<B>>::Output: Zero + AddAssign + Div<<B as Mul>::Output>,
-            <<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output: Copy + Mul<B, Output = A>,
-            B: Mul + Mul<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output, Output = A>, <B as Mul>::Output: Zero + AddAssign { other.scale(dot(self, other)/dot(other, other)) }
+        where N: ArrayLength<B> + ArrayLength<<B as Mul>::Output> + ArrayLength<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output>, <N as ArrayLength<B>>::ArrayType: Copy,
+              A: Mul<B>, <A as Mul<B>>::Output: Zero + AddAssign + Div<<B as Mul>::Output>,
+              <<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output: Copy + Mul<B, Output=A>,
+              B: Mul + Mul<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output, Output=A>, <B as Mul>::Output: Zero + AddAssign { other.scale(dot(self, other) / dot(other, other)) }
 }
 
-impl<A: Copy + Zero + AddAssign + Sub<Output = A>, N: ArrayLength<A>> Matrix<A, N> where N::ArrayType: Copy {
+impl<A: Copy + Zero + AddAssign + Sub<Output=A>, N: ArrayLength<A>> Matrix<A, N> where N::ArrayType: Copy {
     /// Reject self from other.
     #[inline]
     pub fn rej<B: Copy>(self, other: Matrix<B, N>) -> Self
-      where N: ArrayLength<B> + ArrayLength<<B as Mul>::Output> + ArrayLength<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output>, <N as ArrayLength<B>>::ArrayType: Copy,
-            A: Mul<B>, <A as Mul<B>>::Output: Zero + AddAssign + Div<<B as Mul>::Output>,
-            <<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output: Copy + Mul<B, Output = A>,
-            B: Mul + Mul<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output, Output = A>, <B as Mul>::Output: Zero + AddAssign { self - self.proj(other) }
+        where N: ArrayLength<B> + ArrayLength<<B as Mul>::Output> + ArrayLength<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output>, <N as ArrayLength<B>>::ArrayType: Copy,
+              A: Mul<B>, <A as Mul<B>>::Output: Zero + AddAssign + Div<<B as Mul>::Output>,
+              <<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output: Copy + Mul<B, Output=A>,
+              B: Mul + Mul<<<A as Mul<B>>::Output as Div<<B as Mul>::Output>>::Output, Output=A>, <B as Mul>::Output: Zero + AddAssign { self - self.proj(other) }
 }
 
 impl<A, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Matrix<A, M, N> {
-    #[inline] pub const fn from_col_major_array(a: GenericArray<GenericArray<A, M>, N>) -> Self { Matrix(a) }
-    #[inline] pub const fn to_col_major_array(self) -> GenericArray<GenericArray<A, M>, N> {
+    #[inline]
+    pub const fn from_col_major_array(a: GenericArray<GenericArray<A, M>, N>) -> Self { Matrix(a) }
+    #[inline]
+    pub const fn to_col_major_array(self) -> GenericArray<GenericArray<A, M>, N> {
         #[allow(unions_with_drop_fields)]
         union U<A, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> { a: Matrix<A, M, N> }
         let u = U { a: self };
@@ -116,18 +119,19 @@ impl<A: Copy + Zero, M: ArrayLength<A>> Matrix<A, M> {
 impl<A, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Matrix<A, M, N> {
     #[inline]
     pub fn scale<B: Copy>(self, b: B) -> Matrix<A::Output, M, N>
-      where A: Mul<B>,
-            M: ArrayLength<A::Output>,
-            N: ArrayLength<GenericArray<A::Output, M>> { self.map_elements(|a| a*b) }
+        where A: Mul<B>,
+              M: ArrayLength<A::Output>,
+              N: ArrayLength<GenericArray<A::Output, M>> { self.map_elements(|a| a * b) }
     #[inline]
     pub fn unscale<B: Copy>(self, b: B) -> Matrix<A::Output, M, N>
-      where A: Div<B>,
-            M: ArrayLength<A::Output>,
-            N: ArrayLength<GenericArray<A::Output, M>> { self.map_elements(|a| a/b) }
+        where A: Div<B>,
+              M: ArrayLength<A::Output>,
+              N: ArrayLength<GenericArray<A::Output, M>> { self.map_elements(|a| a / b) }
 }
 
 impl<A: Copy, M: ArrayLength<A> + ArrayLength<GenericArray<A, N>>, N: ArrayLength<A> + ArrayLength<GenericArray<A, M>>> Matrix<A, M, N> {
-    #[inline] pub fn transpose(self) -> Matrix<A, N, M> {
+    #[inline]
+    pub fn transpose(self) -> Matrix<A, N, M> {
         let Matrix(a) = self;
         let mut c: GenericArray<GenericArray<A, N>, M> = unsafe { mem::uninitialized() };
         for i in 0..N::to_usize() {
@@ -140,11 +144,13 @@ impl<A: Copy, M: ArrayLength<A> + ArrayLength<GenericArray<A, N>>, N: ArrayLengt
 }
 
 impl<A: Debug, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Debug for Matrix<A, M, N> {
-    #[inline] fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result { self.0.fmt(fmt) }
+    #[inline]
+    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result { self.0.fmt(fmt) }
 }
 
 impl<A: Clone, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Clone for Matrix<A, M, N> where M::ArrayType: Clone {
-    #[inline] fn clone(&self) -> Self {
+    #[inline]
+    fn clone(&self) -> Self {
         unsafe {
             let mut c: GenericArray<GenericArray<A, M>, N> = mem::uninitialized();
             for i in 0..N::to_usize() { for j in 0..M::to_usize() { ptr::write(&mut c[i][j], self.0[i][j].clone()) } }
@@ -156,49 +162,64 @@ impl<A: Clone, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Clone for 
 impl<A: Copy, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Copy for Matrix<A, M, N> where M::ArrayType: Copy, N::ArrayType: Copy {}
 
 impl<A: PartialEq, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> PartialEq for Matrix<A, M, N> {
-    #[inline] fn eq(&self, &Matrix(ref b): &Self) -> bool { let &Matrix(ref a) = self; a == b }
+    #[inline]
+    fn eq(&self, &Matrix(ref b): &Self) -> bool {
+        let &Matrix(ref a) = self;
+        a == b
+    }
 }
 
 impl<A: Eq, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Eq for Matrix<A, M, N> {}
 
 impl<B: Copy, A: Copy + MulAssign<B>, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> MulAssign<B> for Matrix<A, M, N> {
-    #[inline] fn mul_assign(&mut self, rhs: B) {
+    #[inline]
+    fn mul_assign(&mut self, rhs: B) {
         let &mut Matrix(ref mut a) = self;
         for i in 0..N::to_usize() { for j in 0..M::to_usize() { a[i][j] *= rhs } }
     }
 }
 
 impl<A, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Matrix<A, M, N> {
-    #[inline] fn map_elements<B, F: FnMut(A) -> B>(self, mut f: F) -> Matrix<B, M, N>
-      where M: ArrayLength<B>, N: ArrayLength<GenericArray<B, M>> {
+    #[inline]
+    fn map_elements<B, F: FnMut(A) -> B>(self, mut f: F) -> Matrix<B, M, N>
+        where M: ArrayLength<B>, N: ArrayLength<GenericArray<B, M>> {
         let Matrix(a) = self;
-        let _wrapper = mem::ManuallyDrop::new(a);
+        let wrapper = mem::ManuallyDrop::new(a);
         let mut c: GenericArray<GenericArray<B, M>, N> = unsafe { mem::uninitialized() };
-        for i in 0..N::to_usize() { for j in 0..M::to_usize() { unsafe {
-            ptr::write(&mut c[i][j], f(ptr::read(&_wrapper[i][j])))
-        } } }
+        for i in 0..N::to_usize() {
+            for j in 0..M::to_usize() {
+                unsafe {
+                    ptr::write(&mut c[i][j], f(ptr::read(&wrapper[i][j])))
+                }
+            }
+        }
         Matrix(c)
     }
-
 }
 
 #[inline]
 fn zip_elements<A, B, C, M, N, F: FnMut(A, B) -> C>(Matrix(a): Matrix<A, M, N>,
                                                     Matrix(b): Matrix<B, M, N>,
                                                     mut f: F) -> Matrix<C, M, N>
-  where M: ArrayLength<A> + ArrayLength<B> + ArrayLength<C>,
-        N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>> +
-           ArrayLength<GenericArray<C, M>> {
+    where M: ArrayLength<A> + ArrayLength<B> + ArrayLength<C>,
+          N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>> +
+          ArrayLength<GenericArray<C, M>> {
     let mut c: GenericArray<GenericArray<C, M>, N> = unsafe { mem::uninitialized() };
-    for i in 0..N::to_usize() { for j in 0..M::to_usize() { unsafe {
-        ptr::write(&mut c[i][j], f(ptr::read(&a[i][j]), ptr::read(&b[i][j])))
-    } } }
+    let mut wrapper = mem::ManuallyDrop::new(c);
+    for i in 0..N::to_usize() {
+        for j in 0..M::to_usize() {
+            unsafe {
+                ptr::write(&mut wrapper[i][j], f(ptr::read(&a[i][j]), ptr::read(&b[i][j])))
+            }
+        }
+    }
     mem::forget((a, b));
-    Matrix(c)
+    Matrix(mem::ManuallyDrop::into_inner(wrapper))
 }
 
 impl<A: Copy + Zero, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Matrix<A, M, N> {
-    #[inline] pub fn zero() -> Self {
+    #[inline]
+    pub fn zero() -> Self {
         let mut c: GenericArray<GenericArray<A, M>, N> = unsafe { mem::uninitialized() };
         for i in 0..N::to_usize() { for j in 0..M::to_usize() { c[i][j] = A::zero } }
         Matrix(c)
@@ -207,44 +228,50 @@ impl<A: Copy + Zero, M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>> Matr
 
 impl<A: Neg, M: ArrayLength<A> + ArrayLength<A::Output>, N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<A::Output, M>>> Neg for Matrix<A, M, N> {
     type Output = Matrix<A::Output, M, N>;
-    #[inline] fn neg(self) -> Self::Output { self.map_elements(Neg::neg) }
+    #[inline]
+    fn neg(self) -> Self::Output { self.map_elements(Neg::neg) }
 }
 
 impl<B: Copy, A: Copy + Add<B>,
-     M: ArrayLength<A> + ArrayLength<B> + ArrayLength<A::Output>,
-     N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>> + ArrayLength<GenericArray<A::Output, M>>> Add<Matrix<B, M, N>> for Matrix<A, M, N> {
+    M: ArrayLength<A> + ArrayLength<B> + ArrayLength<A::Output>,
+    N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>> + ArrayLength<GenericArray<A::Output, M>>> Add<Matrix<B, M, N>> for Matrix<A, M, N> {
     type Output = Matrix<A::Output, M, N>;
-    #[inline] fn add(self, other: Matrix<B, M, N>) -> Self::Output { zip_elements(self, other, A::add) }
+    #[inline]
+    fn add(self, other: Matrix<B, M, N>) -> Self::Output { zip_elements(self, other, A::add) }
 }
 
 impl<B: Copy, A: Copy + AddAssign<B>,
-     M: ArrayLength<A> + ArrayLength<B>,
-     N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>>> AddAssign<Matrix<B, M, N>> for Matrix<A, M, N> {
-    #[inline] fn add_assign(&mut self, Matrix(b): Matrix<B, M, N>) {
+    M: ArrayLength<A> + ArrayLength<B>,
+    N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>>> AddAssign<Matrix<B, M, N>> for Matrix<A, M, N> {
+    #[inline]
+    fn add_assign(&mut self, Matrix(b): Matrix<B, M, N>) {
         let &mut Matrix(ref mut a) = self;
         for i in 0..N::to_usize() { for j in 0..M::to_usize() { a[i][j] += b[i][j] } }
     }
 }
 
 impl<B: Copy, A: Copy + Sub<B>,
-     M: ArrayLength<A> + ArrayLength<B> + ArrayLength<A::Output>,
-     N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>> + ArrayLength<GenericArray<A::Output, M>>> Sub<Matrix<B, M, N>> for Matrix<A, M, N> {
+    M: ArrayLength<A> + ArrayLength<B> + ArrayLength<A::Output>,
+    N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>> + ArrayLength<GenericArray<A::Output, M>>> Sub<Matrix<B, M, N>> for Matrix<A, M, N> {
     type Output = Matrix<A::Output, M, N>;
-    #[inline] fn sub(self, other: Matrix<B, M, N>) -> Self::Output { zip_elements(self, other, A::sub) }
+    #[inline]
+    fn sub(self, other: Matrix<B, M, N>) -> Self::Output { zip_elements(self, other, A::sub) }
 }
 
 impl<B: Copy, A: Copy + SubAssign<B>,
-     M: ArrayLength<A> + ArrayLength<B>,
-     N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>>> SubAssign<Matrix<B, M, N>> for Matrix<A, M, N> {
-    #[inline] fn sub_assign(&mut self, Matrix(b): Matrix<B, M, N>) {
+    M: ArrayLength<A> + ArrayLength<B>,
+    N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<B, M>>> SubAssign<Matrix<B, M, N>> for Matrix<A, M, N> {
+    #[inline]
+    fn sub_assign(&mut self, Matrix(b): Matrix<B, M, N>) {
         let &mut Matrix(ref mut a) = self;
         for i in 0..N::to_usize() { for j in 0..M::to_usize() { a[i][j] -= b[i][j] } }
     }
 }
 
-impl<A: Copy + Zero + One, N: ArrayLength<A> + ArrayLength<GenericArray<A, N>>> 
+impl<A: Copy + Zero + One, N: ArrayLength<A> + ArrayLength<GenericArray<A, N>>>
 Matrix<A, N, N> {
-    #[inline] pub fn one() -> Self {
+    #[inline]
+    pub fn one() -> Self {
         let mut c: GenericArray<GenericArray<A, N>, N> = unsafe { mem::uninitialized() };
         for i in 0..N::to_usize() { for j in 0..N::to_usize() { c[i][j] = if i == j { A::one } else { A::zero } } }
         Matrix(c)
@@ -252,17 +279,18 @@ Matrix<A, N, N> {
 }
 
 impl<B: Copy, A: Copy + Mul<B>,
-     K: ArrayLength<B> + ArrayLength<GenericArray<A, M>>,
-     M: ArrayLength<A> + ArrayLength<A::Output>,
-     N: ArrayLength<GenericArray<A::Output, M>> + ArrayLength<GenericArray<B, K>>> Mul<Matrix<B, K, N>> for Matrix<A, M, K> where A::Output: Zero + AddAssign {
+    K: ArrayLength<B> + ArrayLength<GenericArray<A, M>>,
+    M: ArrayLength<A> + ArrayLength<A::Output>,
+    N: ArrayLength<GenericArray<A::Output, M>> + ArrayLength<GenericArray<B, K>>> Mul<Matrix<B, K, N>> for Matrix<A, M, K> where A::Output: Zero + AddAssign {
     type Output = Matrix<A::Output, M, N>;
-    #[inline] fn mul(self, Matrix(b): Matrix<B, K, N>) -> Self::Output {
+    #[inline]
+    fn mul(self, Matrix(b): Matrix<B, K, N>) -> Self::Output {
         let Matrix(a) = self;
         let mut c: GenericArray<GenericArray<A::Output, M>, N> = unsafe { mem::uninitialized() };
         for i in 0..N::to_usize() {
             for j in 0..M::to_usize() {
                 c[i][j] = A::Output::zero;
-                for k in 0..K::to_usize() { c[i][j] += a[k][j]*b[i][k] }
+                for k in 0..K::to_usize() { c[i][j] += a[k][j] * b[i][k] }
             }
         }
         Matrix(c)
@@ -271,8 +299,8 @@ impl<B: Copy, A: Copy + Mul<B>,
 
 #[cfg(feature = "dimensioned")]
 impl<A: dim::Dimensioned, M, N> dim::Dimensioned for Matrix<A, M, N>
-  where M: ArrayLength<A> + ArrayLength<A::Value>,
-        N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<A::Value, M>> {
+    where M: ArrayLength<A> + ArrayLength<A::Value>,
+          N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<A::Value, M>> {
     type Value = Matrix<A::Value, M, N>;
     type Units = A::Units;
     #[inline]
@@ -283,8 +311,8 @@ impl<A: dim::Dimensioned, M, N> dim::Dimensioned for Matrix<A, M, N>
 
 #[cfg(feature = "dimensioned")]
 impl<A: dim::Dimensionless, M, N> dim::Dimensionless for Matrix<A, M, N>
-  where M: ArrayLength<A> + ArrayLength<A::Value>,
-        N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<A::Value, M>> {
+    where M: ArrayLength<A> + ArrayLength<A::Value>,
+          N: ArrayLength<GenericArray<A, M>> + ArrayLength<GenericArray<A::Value, M>> {
     #[inline]
     fn value(&self) -> &Self::Value { unsafe { mem::transmute(self) } }
 }
@@ -294,9 +322,9 @@ use quickcheck::*;
 
 #[cfg(any(test, feature = "quickcheck"))]
 impl<A: Copy + Arbitrary, M, N> Arbitrary for Matrix<A, M, N>
-  where M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>,
-        M::ArrayType: Clone, N::ArrayType: Send,
-        Matrix<A, M, N>: 'static {
+    where M: ArrayLength<A>, N: ArrayLength<GenericArray<A, M>>,
+          M::ArrayType: Clone, N::ArrayType: Send,
+          Matrix<A, M, N>: 'static {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let mut c: GenericArray<GenericArray<A, M>, N> = unsafe { mem::uninitialized() };
         for i in 0..N::to_usize() {
@@ -316,13 +344,14 @@ mod tests {
     use super::*;
 
     fn test_multiply_transpose<A: Copy, M, N>(a: Matrix<A, M, N>, b: Matrix<A, N, M>) -> bool
-      where A: Mul, A::Output: Copy + PartialEq + Zero + AddAssign,
-            M: ArrayLength<A> + ArrayLength<GenericArray<A, N>> +
-               ArrayLength<A::Output> + ArrayLength<GenericArray<A::Output, M>>,
-            N: ArrayLength<A> + ArrayLength<GenericArray<A, M>>,
-            Matrix<A, M, N>: Copy, Matrix<A, N, M>: Copy {
-        (a*b).transpose() == b.transpose()*a.transpose()
+        where A: Mul, A::Output: Copy + PartialEq + Zero + AddAssign,
+              M: ArrayLength<A> + ArrayLength<GenericArray<A, N>> +
+              ArrayLength<A::Output> + ArrayLength<GenericArray<A::Output, M>>,
+              N: ArrayLength<A> + ArrayLength<GenericArray<A, M>>,
+              Matrix<A, M, N>: Copy, Matrix<A, N, M>: Copy {
+        (a * b).transpose() == b.transpose() * a.transpose()
     }
+
     #[quickcheck]
     fn multiply_transpose_3by4_isize(a: Matrix<isize, U3, U4>,
                                      b: Matrix<isize, U4, U3>) -> bool {


### PR DESCRIPTION
This should fixes #1 , which wraps a `ManuallyDrop` around the original matrix to prevent unintentional dropping of its elements.